### PR TITLE
address.md: add code examples section

### DIFF
--- a/docs/developers/address.md
+++ b/docs/developers/address.md
@@ -24,3 +24,77 @@ An Ark address is the [bech32m](https://bips.dev/350/) encoding of a prefix, the
 :::tip
 Like Bitcoin, the taproot tree encoded in the ark address is revealed only when the VTXO is spent. If it doesn't pass the server's validation, the owner won't be allowed to spend the VTXO off-chain. The unilateral exit would be the only option.
 :::
+
+## Code Examples
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="programming-language">
+  <TabItem value="typescript" label="TypeScript">
+
+```typescript title="address.ts"
+import { Script, ScriptNum, p2tr, taprootListToTree } from '@scure/btc-signer'
+import { TAPROOT_UNSPENDABLE_KEY } from '@scure/btc-signer/utils'
+import { bech32m } from 'bech32'
+import * as bip68 from 'bip68'
+
+
+/**
+ * Creates a default mainnet Ark address with collaborative and exit script paths
+ * @param serverPubKey - Server's x-only public key (32 bytes)
+ * @param myPubKey - User's x-only public key (32 bytes)
+ * @param exitDelay - Number of blocks required for unilateral exit
+ * @returns bech32m encoded Ark address
+ */
+function makeDefaultArkAddress(
+  serverPubKey: XOnlyPubKey,
+  myPubKey: XOnlyPubKey,
+  timelock: number,
+  isTestnet: boolean
+): string {
+  // create collaborative spending path
+  const forfeit = Script.decode([
+    serverPubKey,
+    'CHECKSIGVERIFY',
+    myPubKey,
+    'CHECKSIG'
+  ])
+  
+  // encode timelock as bip68 sequence
+  const sequence = ScriptNum().encode(
+    BigInt(bip68.encode({ blocks: timelock }))
+  )
+
+  // create unilateral exit path
+  const exit = Script.decode([
+    sequence,
+    'CHECKSEQUENCEVERIFY',
+    'DROP',
+    myPubKey,
+    'CHECKSIG'
+  ])
+  
+  // generate P2TR output key with unspendable key path
+  const vtxoTaprootKey = p2tr(
+    TAPROOT_UNSPENDABLE_KEY,
+    taprootListToTree([forfeit, exit]),
+    undefined,
+    true
+  ).tweakedPubkey
+
+  // combine server pubkey and vtxo taproot key
+  const addressData = new Uint8Array(64)
+  addressData.set(serverPubKey, 0)
+  addressData.set(vtxoTaprootKey, 32)
+
+  return bech32m.encode(
+    isTestnet ? 'tark' : 'ark',    // mainnet prefix
+    bech32m.toWords(addressData),  // convert to 5-bit words
+    1023                           // extends bech32m byte limit
+  );
+}
+```
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
This PR adds a Typescript code example to `address.md` file, showing how to create an ark address from scratch.

@tiero please review